### PR TITLE
Fix some image references found as part of disconnected test

### DIFF
--- a/overlay/acm/acm-2.14/rpa-dev.yaml
+++ b/overlay/acm/acm-2.14/rpa-dev.yaml
@@ -22,7 +22,7 @@ spec:
         - name: multicluster-operators-channel-acm-214
           repository: quay.io/acm-d/multicluster-operators-channel-rhel9
         - name: must-gather-acm-214
-          repository: quay.io/acm-d/must-gather-rhel9
+          repository: quay.io/acm-d/acm-must-gather-rhel9
         - name: governance-policy-addon-controller-acm-214
           repository: quay.io/acm-d/acm-governance-policy-addon-controller-rhel9
         - name: search-indexer-acm-214
@@ -38,7 +38,7 @@ spec:
         - name: grafana-acm-214
           repository: quay.io/acm-d/acm-grafana-rhel9
         - name: prometheus-operator-acm-214
-          repository: quay.io/acm-d/prometheus-rhel9
+          repository: quay.io/acm-d/acm-prometheus-rhel9
         - name: multicluster-operators-subscription-acm-214
           repository: quay.io/acm-d/multicluster-operators-subscription-rhel9
         - name: cluster-permission-acm-214

--- a/overlay/acm/acm-2.14/rpa-prod.yaml
+++ b/overlay/acm/acm-2.14/rpa-prod.yaml
@@ -25,7 +25,7 @@ spec:
         - name: multicluster-operators-channel-acm-214
           repository: registry.redhat.io/rhacm2/multicluster-operators-channel-rhel9
         - name: must-gather-acm-214
-          repository: registry.redhat.io/rhacm2/must-gather-rhel9
+          repository: registry.redhat.io/rhacm2/acm-must-gather-rhel9
         - name: governance-policy-addon-controller-acm-214
           repository: registry.redhat.io/rhacm2/governance-policy-addon-controller-rhel9
         - name: search-indexer-acm-214
@@ -41,7 +41,7 @@ spec:
         - name: grafana-acm-214
           repository: registry.redhat.io/rhacm2/acm-grafana-rhel9
         - name: prometheus-operator-acm-214
-          repository: registry.redhat.io/rhacm2/prometheus-rhel9
+          repository: registry.redhat.io/rhacm2/acm-prometheus-rhel9
         - name: multicluster-operators-subscription-acm-214
           repository: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9
         - name: cluster-permission-acm-214


### PR DESCRIPTION
I updated the dev rpa and prod rpa which I verified with local dev testing and checking the catalog.  There do seem to be prometheus images missing from stage and prod and I think stage may have a lot of rhel9 suffixes that might not be needed?  I don't know for sure about those so did not make additional changes.

Refs:
 - https://issues.redhat.com/browse/ACM-21584